### PR TITLE
Add support for split variables for commands like variable set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,93 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# IntelliJ
+.idea/*
+*.iml

--- a/plugins/rest_api_plugin.py
+++ b/plugins/rest_api_plugin.py
@@ -127,7 +127,7 @@ apis_metadata = [
         "airflow_version": "1.7.1 or greater",
         "http_method": "GET",
         "arguments": [
-            {"name": "set", "description": "Set a variable. Expected input in the form: KEY VALUE.", "form_input_type": "text", "required": False},
+            {"name": "set", "description": "Set a variable. Expected input in the form: KEY VALUE.", "form_input_type": "text", "required": False, "split": True},
             {"name": "get", "description": "Get value of a variable", "form_input_type": "text", "required": False},
             {"name": "json", "description": "Deserialize JSON variable", "form_input_type": "checkbox", "required": False},
             {"name": "default", "description": "Default value returned if variable does not exist", "form_input_type": "text", "required": False},
@@ -637,7 +637,10 @@ class REST_API(BaseView):
                     if argument["form_input_type"] is not "checkbox":
                         # Relacing airflow_cmd_split.extend(argument_value.split(" ") with command below to fix issue where configuration 
                         # values contain space with them.
-                        airflow_cmd_split.append(argument_value)
+                        if 'split' in argument and argument['split']: # split the argument
+                            airflow_cmd_split.extend(argument_value.split())
+                        else:
+                            airflow_cmd_split.append(argument_value)
             else:
                 logging.warning("argument_value is null")
 


### PR DESCRIPTION
* Add support for split arguments to be passed to Airflow
* Currently supports airflow variable --set KEY VAL
* Can be modified to support any additional calls via `apis_metadata` dict updates with `split` key