### PR TITLE
Add support for POST requests

### DIFF
--- a/plugins/rest_api_plugin.py
+++ b/plugins/rest_api_plugin.py
@@ -99,21 +99,21 @@ apis_metadata = [
         "name": "version",
         "description": "Displays the version of Airflow you're using",
         "airflow_version": "1.0.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": []
     },
     {
         "name": "rest_api_plugin_version",
         "description": "Displays the version of this REST API Plugin you're using",
         "airflow_version": "None - Custom API",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": []
     },
     {
         "name": "render",
         "description": "Render a task instance's template(s)",
         "airflow_version": "1.7.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_id", "description": "The id of the task", "form_input_type": "text", "required": True, "cli_end_position": 2},
@@ -125,7 +125,7 @@ apis_metadata = [
         "name": "variables",
         "description": "CRUD operations on variables",
         "airflow_version": "1.7.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "set", "description": "Set a variable. Please enter both key and value", "form_input_type": "keyValue", "required": False},
             {"name": "get", "description": "Get value of a variable", "form_input_type": "text", "required": False},
@@ -140,7 +140,7 @@ apis_metadata = [
         "name": "connections",
         "description": "List/Add/Delete connections",
         "airflow_version": "1.8.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "list", "description": "List all connections", "form_input_type": "checkbox", "required": False},
             {"name": "add", "description": "Add a connection", "form_input_type": "checkbox", "required": False},
@@ -154,7 +154,7 @@ apis_metadata = [
         "name": "pause",
         "description": "Pauses a DAG",
         "airflow_version": "1.7.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "subdir", "description": "File location or directory from which to look for the dag", "form_input_type": "text", "required": False}
@@ -164,7 +164,7 @@ apis_metadata = [
         "name": "unpause",
         "description": "Unpauses a DAG",
         "airflow_version": "1.7.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "subdir", "description": "File location or directory from which to look for the dag", "form_input_type": "text", "required": False}
@@ -174,7 +174,7 @@ apis_metadata = [
         "name": "task_failed_deps",
         "description": "Returns the unmet dependencies for a task instance from the perspective of the scheduler. In other words, why a task instance doesn't get scheduled and then queued by the scheduler, and then run by an executor).",
         "airflow_version": "1.8.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_id", "description": "The id of the task", "form_input_type": "text", "required": True, "cli_end_position": 2},
@@ -186,7 +186,7 @@ apis_metadata = [
         "name": "trigger_dag",
         "description": "Trigger a DAG run",
         "airflow_version": "1.6.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "subdir", "description": "File location or directory from which to look for the dag", "form_input_type": "text", "required": False},
@@ -199,7 +199,7 @@ apis_metadata = [
         "name": "test",
         "description": "Test a task instance. This will run a task without checking for dependencies or recording it's state in the database.",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_id", "description": "The id of the task", "form_input_type": "text", "required": True, "cli_end_position": 2},
@@ -213,7 +213,7 @@ apis_metadata = [
         "name": "dag_state",
         "description": "Get the status of a dag run",
         "airflow_version": "1.8.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "execution_date", "description": "The execution date of the DAG (Example: 2017-01-02T03:04:05)", "form_input_type": "text", "required": True, "cli_end_position": 2},
@@ -224,7 +224,7 @@ apis_metadata = [
         "name": "run",
         "description": "Run a single task instance",
         "airflow_version": "1.0.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_id", "description": "The id of the task", "form_input_type": "text", "required": True, "cli_end_position": 2},
@@ -246,7 +246,7 @@ apis_metadata = [
         "name": "list_tasks",
         "description": "List the tasks within a DAG",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "tree", "description": "Tree view", "form_input_type": "checkbox", "required": False},
@@ -257,7 +257,7 @@ apis_metadata = [
         "name": "backfill",
         "description": "Run subsections of a DAG for a specified date range",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_regex", "description": "The regex to filter specific task_ids to backfill (optional)", "form_input_type": "text", "required": False},
@@ -278,7 +278,7 @@ apis_metadata = [
         "name": "list_dags",
         "description": "List all the DAGs",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "subdir", "description": "File location or directory from which to look for the dag", "form_input_type": "text", "required": False},
             {"name": "report", "description": "Show DagBag loading report", "form_input_type": "checkbox", "required": False}
@@ -288,7 +288,7 @@ apis_metadata = [
         "name": "kerberos",
         "description": "Start a kerberos ticket renewer",
         "airflow_version": "1.6.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "background_mode": True,
         "arguments": [
             {"name": "principal", "description": "kerberos principal", "form_input_type": "text", "required": True, "cli_end_position": 1},
@@ -304,7 +304,7 @@ apis_metadata = [
         "name": "worker",
         "description": "Start a Celery worker node",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "background_mode": True,
         "arguments": [
             {"name": "do_pickle", "description": "Attempt to pickle the DAG object to send over to the workers, instead of letting workers run their version of the code.", "form_input_type": "checkbox", "required": False},
@@ -321,7 +321,7 @@ apis_metadata = [
         "name": "flower",
         "description": "Start a Celery worker node",
         "airflow_version": "1.0.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "background_mode": True,
         "arguments": [
             {"name": "hostname", "description": "Set the hostname on which to run the server", "form_input_type": "text", "required": False},
@@ -339,7 +339,7 @@ apis_metadata = [
         "name": "scheduler",
         "description": "Start a scheduler instance",
         "airflow_version": "1.0.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "background_mode": True,
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": False},
@@ -358,7 +358,7 @@ apis_metadata = [
         "name": "task_state",
         "description": "Get the status of a task instance",
         "airflow_version": "1.0.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_id", "description": "The id of the task", "form_input_type": "text", "required": True, "cli_end_position": 2},
@@ -370,7 +370,7 @@ apis_metadata = [
         "name": "pool",
         "description": "CRUD operations on pools",
         "airflow_version": "1.8.0 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "set", "description": "Set pool slot count and description, respectively. Expected input in the form: NAME SLOT_COUNT POOL_DESCRIPTION.", "form_input_type": "text", "required": False},
             {"name": "get", "description": "Get pool info", "form_input_type": "text", "required": False},
@@ -381,7 +381,7 @@ apis_metadata = [
         "name": "serve_logs",
         "description": "Serve logs generate by worker",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "background_mode": True,
         "arguments": []
     },
@@ -389,7 +389,7 @@ apis_metadata = [
         "name": "clear",
         "description": "Clear a set of task instance, as if they never ran",
         "airflow_version": "0.1 or greater",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True, "cli_end_position": 1},
             {"name": "task_regex", "description": "The regex to filter specific task_ids to backfill (optional)", "form_input_type": "text", "required": False},
@@ -425,7 +425,7 @@ apis_metadata = [
         "name": "refresh_dag",
         "description": "Refresh a DAG in the Web Server",
         "airflow_version": "None - Custom API",
-        "http_method": "GET",
+        "http_method": ["GET", "POST"],
         "arguments": [
             {"name": "dag_id", "description": "The id of the dag", "form_input_type": "text", "required": True}
         ]
@@ -521,6 +521,10 @@ class REST_API(BaseView):
     def get_dagbag():
         return DagBag()
 
+    @staticmethod
+    def get_argument(request, arg):
+        return request.args.get(arg) or request.form.get(arg)
+
     # '/' Endpoint where the Admin page is which allows you to view the APIs available and trigger them
     @expose('/')
     def index(self):
@@ -553,7 +557,7 @@ class REST_API(BaseView):
         base_response = REST_API_Response_Util.get_base_response()
 
         # Get the api that you want to execute
-        api = request.args.get('api')
+        api = self.get_argument(request, 'api')
         if api is not None:
             api = api.strip().lower()
         logging.info("REST_API.api() called (api: " + str(api) + ")")
@@ -577,7 +581,7 @@ class REST_API(BaseView):
         dag_id = None
         for argument in api_metadata["arguments"]:
             argument_name = argument["name"]
-            argument_value = request.args.get(argument_name)
+            argument_value = self.get_argument(request, argument_name)
             if argument["required"]:
                 if self.is_arg_not_provided(argument_value):
                     missing_required_arguments.append(argument_name)
@@ -627,7 +631,7 @@ class REST_API(BaseView):
         end_arguments = [0] * largest_end_argument_value
         for argument in api_metadata["arguments"]:
             argument_name = argument["name"]
-            argument_value = request.args.get(argument_name)
+            argument_value = self.get_argument(request, argument_name)
             logging.info("argument_name: " + str(argument_name) + ", argument_value: " + str(argument_value))
             if argument_value is not None:
                 if run_api_in_background_mode:
@@ -643,7 +647,7 @@ class REST_API(BaseView):
                     if argument["form_input_type"] is not "checkbox":
                         if argument["form_input_type"] == "keyValue":
                             key = argument_value
-                            value = request.args.get(argument_name + "_value")
+                            value = self.get_argument(request, argument_name + "_value")
                             if value is None:
                                 return REST_API_Response_Util.get_400_error_response(base_response,
                                                                                      "'" + argument_name + "_value' is required")
@@ -672,7 +676,7 @@ class REST_API(BaseView):
         # handling the case where the process should be ran in the background
         if run_api_in_background_mode:
             # if a log file is provided, then that should be used to dump the output of the call
-            if request.args.get("log-file") is None:
+            if self.get_argument(request, "log-file") is None:
                 airflow_cmd_split.append(">> " + str(airflow_base_log_folder) + "/" + api_metadata["name"] + ".log")
             # appending a '&' character to run the process in the background
             airflow_cmd_split.append("&")
@@ -770,7 +774,7 @@ class REST_API(BaseView):
     # This will call the direct function corresponding to the web endpoint '/admin/airflow/refresh' that already exists in Airflow
     def refresh_dag(self, base_response):
         logging.info("Executing custom 'refresh_dag' function")
-        dag_id = request.args.get('dag_id')
+        dag_id = self.get_argument(request, 'dag_id')
         logging.info("dag_id to refresh: '" + str(dag_id) + "'")
         if self.is_arg_not_provided(dag_id):
             return REST_API_Response_Util.get_400_error_response(base_response, "dag_id should be provided")


### PR DESCRIPTION
See https://github.com/apache/airflow/pull/5202
>Airflow uses gunicorn under the hood to run the web server, however, there is no way to pass configuration parameters to it. For example, we are using the rest-api plugin for the airflow to start tasks from API, and we are facing the issue that the POST request is limited to the 4096 characters. We would like to increase that limit.

In order to send a big `conf` to the `trigger_dag` entrypoint using a POST request, the following modifications were made.
