### PR TITLE
Use utf-8 decoding on output messages

### DIFF
--- a/plugins/rest_api_plugin.py
+++ b/plugins/rest_api_plugin.py
@@ -865,15 +865,15 @@ class REST_API(BaseView):
         if process.stderr is not None:
             output["stderr"] = ""
             for line in process.stderr.readlines():
-                output["stderr"] += str(line)
+                output["stderr"] += str(line.decode('utf-8'))
         if process.stdin is not None:
             output["stdin"] = ""
             for line in process.stdin.readlines():
-                output["stdin"] += str(line)
+                output["stdin"] += str(line.decode('utf-8'))
         if process.stdout is not None:
             output["stdout"] = ""
             for line in process.stdout.readlines():
-                output["stdout"] += str(line)
+                output["stdout"] += str(line.decode('utf-8'))
         logging.info("RestAPI Output: " + str(output))
         return output
 


### PR DESCRIPTION
Hey, I used this temporary fix on my local in order to filter out standard loading messages, I think this fix should be merged as well for other people to use it.

This is the issue I am referring to #51 