### PR TITLE
Fixed REST API admin page issue with deploy_dag

### DIFF
--- a/plugins/rest_api_plugin.py
+++ b/plugins/rest_api_plugin.py
@@ -442,7 +442,7 @@ apis_metadata = [
         "name": "deploy_dag",
         "description": "Deploy a new DAG File to the DAGs directory",
         "airflow_version": "None - Custom API",
-        "http_method": "POST",
+        "http_method": ["POST"],
         "post_body_description": "dag_file - POST Body Element - REQUIRED",
         "form_enctype": "multipart/form-data",
         "arguments": [],


### PR DESCRIPTION
The deploy_dag section on the admin page allows execution of the deploy_dag API. However, a minor bug with the HTTP verb causes the request to miss the file.